### PR TITLE
Fixed case sensitive filename to match classname

### DIFF
--- a/src/VDB/Spider/Uri/FilterableUri.php
+++ b/src/VDB/Spider/Uri/FilterableUri.php
@@ -1,0 +1,55 @@
+<?php
+namespace VDB\Spider\Uri;
+
+use VDB\Spider\Filterable;
+use VDB\Uri\Uri;
+
+/**
+ * @author Matthijs van den Bos
+ * @copyright 2013 Matthijs van den Bos
+ */
+class FilterableUri extends Uri implements Filterable
+{
+    /** @var bool if the link should be skipped */
+    private $isFiltered = false;
+
+    /** @var string */
+    private $filterReason = '';
+
+    /**
+     * @param boolean $filtered
+     * @param string $reason
+     */
+    public function setFiltered($filtered = true, $reason = '')
+    {
+        $this->isFiltered = $filtered;
+        $this->filterReason = $reason;
+    }
+
+    /**
+     * @return boolean whether the object was filtered
+     */
+    public function isFiltered()
+    {
+        return $this->isFiltered;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilterReason()
+    {
+        return $this->filterReason;
+    }
+
+    /**
+     * Get a unique identifier for the filterable item
+     * Used for reporting
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->toString();
+    }
+}


### PR DESCRIPTION
This caused an issue with autoloading on Linux systems

Basically, renamed filename from 'FilterableURI.php' to 'FilterableUri.php', which contained a classname of 'FilterableUri'
