### PR TITLE
added command line check

### DIFF
--- a/src/VDB/Spider/Spider.php
+++ b/src/VDB/Spider/Spider.php
@@ -94,11 +94,13 @@ class Spider
         }
 
         // This makes the spider handle signals gracefully and allows us to do cleanup
-        declare(ticks = 1);
-        pcntl_signal(SIGTERM, array($this, 'handleSignal'));
-        pcntl_signal(SIGINT, array($this, 'handleSignal'));
-        pcntl_signal(SIGHUP, array($this, 'handleSignal'));
-        pcntl_signal(SIGQUIT, array($this, 'handleSignal'));
+        if(php_sapi_name() == 'cli'){
+            declare(ticks = 1);
+            pcntl_signal(SIGTERM, array($this, 'handleSignal'));
+            pcntl_signal(SIGINT, array($this, 'handleSignal'));
+            pcntl_signal(SIGHUP, array($this, 'handleSignal'));
+            pcntl_signal(SIGQUIT, array($this, 'handleSignal'));
+        }
     }
 
     /**


### PR DESCRIPTION
If php-spider is not envoked from the command line, then the script will fail due to pcntl_signal not being available. I've simply wrapped that part in a conditional check to make sure we're using the command line.
