### PR TITLE
Made vendors more flexible.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,16 @@
         "php": ">=5.3.0",
         "ext-curl": "*",
         "guzzle/guzzle": ">=3.0, <3.4",
-        "symfony/css-selector": "~2.1",
-        "symfony/dom-crawler": "~2.1",
-        "symfony/finder": "2.2.*@dev",
+        "symfony/css-selector": ">=2.1, <3.0",
+        "symfony/dom-crawler": ">=2.1, <3.0",
+        "symfony/finder": ">=2.2, <3.0",
         "vdb/uri": "dev-master",
         "react/react": "0.3.*"
     },
     "require-dev": {
         "monolog/monolog": "1.4.*@dev",
-        "doctrine/cache": "dev-master"
+        "doctrine/cache": "dev-master",
+        "phpunit/phpunit": "~4"
     },
     "autoload": {
         "psr-0": {

--- a/src/VDB/Spider/Spider.php
+++ b/src/VDB/Spider/Spider.php
@@ -24,9 +24,6 @@ use VDB\Uri\Uri;
 use VDB\Uri\Http;
 use VDB\Uri\UriInterface;
 
-/**
- *
- */
 class Spider
 {
     const ALGORITHM_DEPTH_FIRST = 0;
@@ -84,12 +81,18 @@ class Spider
      * @param string $seed the URI to start crawling
      * @param string $spiderId
      */
-    public function __construct($seed, $spiderId = null)
+    public function __construct($seed = null, $spiderId = null)
     {
-        $this->setSeed($seed);
+        if (null !== $seed) {
+            $this->setSeed($seed);
+        }
+
+
         if (null !== $spiderId) {
             $this->spiderId = $spiderId;
-        } else {
+        }
+
+        if (null === $spiderId && null !== $seed) {
             $this->spiderId = md5($seed . microtime(true));
         }
 
@@ -513,9 +516,11 @@ class Spider
     /**
      * @param string $uri
      */
-    private function setSeed($uri)
+    public function setSeed($uri)
     {
+        $this->spiderId = md5($uri . microtime(true));
         $this->seed = new Http($uri);
+
         array_push($this->traversalQueue, $this->seed);
         $this->alreadySeenUris[$this->seed->normalize()->toString()] = 0;
     }

--- a/src/VDB/Spider/Spider.php
+++ b/src/VDB/Spider/Spider.php
@@ -524,4 +524,16 @@ class Spider
         array_push($this->traversalQueue, $this->seed);
         $this->alreadySeenUris[$this->seed->normalize()->toString()] = 0;
     }
+
+    /**
+     * Returns the URL where the crawler is started with.
+     *
+     * @return string
+     */
+    public function getStartUri()
+    {
+        if (null !== $this->seed) {
+            return $this->seed->normalize()->toString();
+        }
+    }
 }


### PR DESCRIPTION
**Composer.json:**

Changed to make the version deps more flexible. There doesn't seem to be a BC break anyware (I checked the source) and tested the complex example of the crawler and it still worked out.

**Other changes:**

Made the constructor arguments optional so the spider can be used as a service in a symfony container.