### PR TITLE
Encode persisted file names as md5 [Closes #35]

### DIFF
--- a/src/VDB/Spider/PersistenceHandler/FilePersistenceHandler.php
+++ b/src/VDB/Spider/PersistenceHandler/FilePersistenceHandler.php
@@ -81,6 +81,17 @@ abstract class FilePersistenceHandler implements PersistenceHandlerInterface
     }
 
     /**
+     * Encodes file name into suitable format and trims its size.
+     * File name length is limited 255 chars, on Win32 a whole file path is limited 260 chars.
+     * @param string $fileName
+     * @return string
+     */
+    protected function encodeFileName($fileName)
+    {
+        return md5($fileName);
+    }
+
+    /**
      * @return Resource
      */
     abstract public function current();

--- a/src/VDB/Spider/PersistenceHandler/FileSerializedResourcePersistenceHandler.php
+++ b/src/VDB/Spider/PersistenceHandler/FileSerializedResourcePersistenceHandler.php
@@ -14,7 +14,7 @@ class FileSerializedResourcePersistenceHandler extends FilePersistenceHandler im
 {
     public function persist(Resource $resource)
     {
-        $fileName = urlencode($resource->getUri()->toString());
+        $fileName = $this->encodeFileName($resource->getUri()->toString());
         $file = new \SplFileObject($this->getResultPath() . $fileName, 'w');
         $this->totalSizePersisted += $file->fwrite(serialize($resource));
     }


### PR DESCRIPTION
`urlencode()` can generate larger file name than 255 characters.

See #35