### PR TITLE
Revert to the legacy EventDispatcher

### DIFF
--- a/src/VDB/Spider/Downloader/Downloader.php
+++ b/src/VDB/Spider/Downloader/Downloader.php
@@ -5,7 +5,7 @@ namespace VDB\Spider\Downloader;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use VDB\Spider\Event\SpiderEvents;
 use VDB\Spider\Filter\PostFetchFilterInterface;
 use VDB\Spider\PersistenceHandler\MemoryPersistenceHandler;
@@ -91,7 +91,7 @@ class Downloader implements DownloaderInterface
      */
     private function dispatch($eventName, Event $event = null)
     {
-        $this->getDispatcher()->dispatch($event, $eventName);
+        $this->getDispatcher()->dispatch($eventName, $event);
     }
 
     /**

--- a/src/VDB/Spider/QueueManager/InMemoryQueueManager.php
+++ b/src/VDB/Spider/QueueManager/InMemoryQueueManager.php
@@ -72,6 +72,7 @@ class InMemoryQueueManager implements QueueManagerInterface
 
     /**
      * @param DiscoveredUri
+     * @throws QueueException
      */
     public function addUri(DiscoveredUri $uri)
     {
@@ -83,8 +84,8 @@ class InMemoryQueueManager implements QueueManagerInterface
         array_push($this->traversalQueue, $uri);
 
         $this->getDispatcher()->dispatch(
-            new GenericEvent($this, array('uri' => $uri)),
-            SpiderEvents::SPIDER_CRAWL_POST_ENQUEUE
+            SpiderEvents::SPIDER_CRAWL_POST_ENQUEUE,
+            new GenericEvent($this, array('uri' => $uri))
         );
     }
 

--- a/src/VDB/Spider/Spider.php
+++ b/src/VDB/Spider/Spider.php
@@ -227,7 +227,7 @@ class Spider
      */
     private function dispatch($eventName, Event $event = null)
     {
-        $this->getDispatcher()->dispatch($event, $eventName);
+        $this->getDispatcher()->dispatch($eventName, $event);
     }
 
     /**


### PR DESCRIPTION
Fortunately, the normal EventDispatcher from S4 also has BC support for the order of the arguments, so I will revert back to that. This way we can keep supporting Symfony 4 for now.

By the time S5 is released in November, this BC support will be dropped. Then I will have to swap the arguments and drop support for S3.