### PR TITLE
Allowing guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.2",
         "ext-dom": "*",
-        "guzzlehttp/guzzle": "^6.0.0|^7.0.0",
+        "guzzlehttp/guzzle": "^6.0.0||^7.0.0",
         "symfony/css-selector": "^3.0.0||^4.0.0||^5.0.0",
         "symfony/dom-crawler": "^3.0.0||^4.0.0||^5.0.0",
         "symfony/finder": "^3.0.0||^4.0.0||^5.0.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.2",
         "ext-dom": "*",
-        "guzzlehttp/guzzle": "^6.0.0",
+        "guzzlehttp/guzzle": "^6.0.0|^7.0.0",
         "symfony/css-selector": "^3.0.0||^4.0.0||^5.0.0",
         "symfony/dom-crawler": "^3.0.0||^4.0.0||^5.0.0",
         "symfony/finder": "^3.0.0||^4.0.0||^5.0.0",


### PR DESCRIPTION
Hello @mvdbos 

in my [Laravel sitemap generator](https://github.com/bringyourownideas/laravel-sitemap) I use your PHP spider. While making it work for Laravel 8 I stumbled upon a conflict in the required versions of guzzle. 

Here is an update of the composer.json to allow guzzle v7. I've ran the unit tests and examples. Both worked and didn't indicate any issues with the update. Do you think is good for merging?

Cheers,
Peter