### PR TITLE
Add PHP 8.4 to the workflow matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Since 8.0 is dead, what do you think of dropping it?  PHP 8.5 will be out in a few weeks, we could also add it to the matrix.