### PR TITLE
Make phan/phan a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         "symfony/finder": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/event-dispatcher": "^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "vdb/uri": "^0.3.2",
-        "spatie/robots-txt": "^2.0",
-        "phan/phan": "^4.0||^5.0||^6.0"
+        "spatie/robots-txt": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0.0",
         "squizlabs/php_codesniffer": "^4.0.0",
+        "phan/phan": "^4.0||^5.0||^6.0",
         "phpmd/phpmd": "^2.0.0",
         "friendsofphp/php-cs-fixer": "^3.69.0"
     },


### PR DESCRIPTION
It does not look that this projects actually uses phan as a dependency but rather as a static analyzer for development...
Upgrading projects using php-spider to Symfony 8 is blocked because phan/phan wants symfony/console < 8.
But this constraint is irrelevant on runtime...