### PR TITLE
Make pdepend/pdepend a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-dom": "*",
         "ext-pcntl": "*",
         "guzzlehttp/guzzle": "^6.0.0||^7.0.0",
-        "pdepend/pdepend": "^2.16.1",
         "symfony/css-selector": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/dom-crawler": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/finder": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
@@ -29,6 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0.0",
         "squizlabs/php_codesniffer": "^4.0.0",
+        "pdepend/pdepend": "^2.16.1",
         "phan/phan": "^4.0||^5.0||^6.0",
         "phpmd/phpmd": "^2.0.0",
         "friendsofphp/php-cs-fixer": "^3.69.0"


### PR DESCRIPTION
Sorry for not identifying this earlier (`composer update` does not list every incompatibility at once but rather displays another one after the 1st one is fixed).
We have the same issue as with phan/phan: pdepend/pdepend is not yet compatible with Symfony 8, but it does not seem to be used by php-spider.
I move it to dev dependencies, but you may want to remove it completely? Or call `vendor/bin/pdepend` in the tests and do something with the output?
Best regards