### PR TITLE
[draft] Replace vdp/uri with PHP native Uri\Rfc3986\Uri

### DIFF
--- a/.github/LOCAL_TESTING.md
+++ b/.github/LOCAL_TESTING.md
@@ -9,21 +9,20 @@ This project is configured to run GitHub Actions locally using [nektos/act](http
 
 ## Quick Start
 
-### Fastest Path: Validate with PHP 8.0 Only
+### Fastest Path: Validate with PHP 8.5
 
 For developers making changes, use this to validate quickly before pushing:
 
 ```bash
-# Run full CI validation with PHP 8.0 (lowest supported version)
-# This is the recommended default - CI will test all versions
+# Run full CI validation with PHP 8.5 (the only supported version)
 ./bin/check
 ```
 
 ### Full act Usage
 
 ```bash
-# Run all workflows (push event) with PHP 8.0
-./bin/act --matrix php-versions:8.0
+# Run all workflows (push event) with PHP 8.5
+./bin/act --matrix php-versions:8.5
 
 # Run workflows for pull request event
 ./bin/act pull_request
@@ -35,7 +34,7 @@ For developers making changes, use this to validate quickly before pushing:
 ./bin/act -l
 
 # Run with specific PHP version matrix
-./bin/act --matrix php-versions:8.3
+./bin/act --matrix php-versions:8.5
 
 # Dry run (don't execute, just show what would run)
 ./bin/act -n
@@ -95,20 +94,15 @@ Run with verbose output:
 
 ## Matrix Testing
 
-**Recommended for CI validation**: Always test with PHP 8.0 only (lowest supported version). CI will automatically run the full matrix across all supported versions:
+**Recommended for CI validation**: PHP-Spider requires PHP >= 8.5, so there is a single supported version to test:
 
 ```bash
-# Default and recommended - validates with PHP 8.0
+# Default and recommended - validates with PHP 8.5
 ./bin/check
 
-# Explicitly with PHP 8.0 (same as check)
-./bin/act --matrix php-versions:8.0
-
-# To test a different version manually:
-./bin/act --matrix php-versions:8.3
+# Explicitly with PHP 8.5 (same as check)
+./bin/act --matrix php-versions:8.5
 ```
-
-**Note**: Do not run the full matrix locally (`--matrix php-versions:8.0,8.1,8.2,8.3`). CI handles cross-version testing automatically.
 
 ## What Gets Tested Locally
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,18 +1,18 @@
 # PHP-Spider – Copilot Guide
 
-- Project shape: a configurable crawler around Guzzle + Symfony components (dom-crawler, css-selector, finder, event-dispatcher) and vdb/uri. Entry point and orchestration live in [src/Spider.php](src/Spider.php); examples are in [example/](example/).
+- Project shape: a configurable crawler around Guzzle + Symfony components (dom-crawler, css-selector, finder, event-dispatcher) and the native `Uri\Rfc3986\Uri` class (`ext-uri`). Entry point and orchestration live in [src/Spider.php](src/Spider.php); examples are in [example/](example/).
 - Crawl loop: `Spider::crawl()` seeds the queue, sets the persistence handler spider id, fires a `spider.crawl.pre_crawl` event, then iterates `doCrawl()` pulling URIs from the queue, downloading, persisting, dispatching `spider.crawl.resource.persisted`, and feeding discoveries back into the queue.
 - Traversal and queueing: [src/QueueManager/InMemoryQueueManager.php](src/QueueManager/InMemoryQueueManager.php) defaults to depth-first; switch with `setTraversalAlgorithm(ALGORITHM_BREADTH_FIRST)`. `maxQueueSize` stops discovery once reached (throws `MaxQueueSizeExceededException`); enqueue emits `spider.crawl.post.enqueue`.
 - Discovery pipeline: [src/Discoverer/DiscovererSet.php](src/Discoverer/DiscovererSet.php) holds discoverers + prefetch filters, tracks already-seen URIs, and enforces `maxDepth` (default 3) to stop recursion. Register discoverers via `addDiscoverer()` and filters via `addFilter()`.
 - Download pipeline: [src/Downloader/Downloader.php](src/Downloader/Downloader.php) uses a `RequestHandlerInterface` (default [GuzzleRequestHandler](src/RequestHandler/GuzzleRequestHandler.php)) and a `PersistenceHandlerInterface` (default [MemoryPersistenceHandler](src/PersistenceHandler/MemoryPersistenceHandler.php)). `downloadLimit` caps persisted resources. Postfetch filters run before persistence and emit `spider.crawl.filter.postfetch`.
 - Resource model: [src/Resource.php](src/Resource.php) wraps `DiscoveredUri` + PSR-7 response and lazily creates a Symfony `Crawler` with response body and content-type; it serializes by storing the raw message for file-based persistence.
 - Persistence options: in-memory for small runs; file-based handlers in [src/PersistenceHandler](src/PersistenceHandler) write per-spider-id directories and serialize resources (`FileSerializedResourcePersistenceHandler` keeps the PSR-7 response intact). Set `setSpiderId()` before persisting.
-- URI model: [src/Uri/DiscoveredUri.php](src/Uri/DiscoveredUri.php) decorates `vdb/uri` with `depthFound` to drive depth filtering and normalization/de-duplication.
+- URI model: [src/Uri/DiscoveredUri.php](src/Uri/DiscoveredUri.php) decorates the native `Uri\Rfc3986\Uri` with `depthFound` to drive depth filtering and de-duplication. `Uri\Rfc3986\Uri` normalizes case, dot-segments, and percent-encoding while parsing, so no separate normalization step is needed.
 - Filters: prefetch filters live in [src/Filter/Prefetch](src/Filter/Prefetch) (e.g., `RestrictToBaseUriFilter`, `AllowedHostsFilter`, regex-based `UriFilter`, robots.txt-aware `RobotsTxtDisallowFilter`); postfetch filters in [src/Filter/Postfetch](src/Filter/Postfetch) (e.g., `MimeTypeFilter`). Filters return true to skip.
 - Events and extensibility: events declared in [src/Event/SpiderEvents.php](src/Event/SpiderEvents.php); dispatcher shared via [DispatcherTrait](src/Event/DispatcherTrait.php). Typical listeners: pre-request throttling ([src/EventListener/PolitenessPolicyListener.php](src/EventListener/PolitenessPolicyListener.php) hooks `spider.crawl.pre_request`) and stats collection example in [example/lib/Example/StatsHandler.php](example/lib/Example/StatsHandler.php).
 - HTTP handling: default Guzzle handler throws on 4XX/5XX; to keep crawling on errors, supply a custom `RequestHandlerInterface` (see link-checker example referenced in [README](README.md)). Signals (SIGTERM/SIGINT/etc.) trigger `spider.crawl.user.stopped` when running in CLI.
 - Key tuning knobs: `DiscovererSet::$maxDepth`, `QueueManager::$maxQueueSize`, `Downloader::setDownloadLimit()`, traversal algorithm, request delay via politeness listener, robots.txt user-agent.
-- Coding standards: PSR-0/1/2; codebase targets PHP >= 8.0. Autoload via PSR-4 `VDB\Spider\` from `src/`.
+- Coding standards: PSR-0/1/2; codebase targets PHP >= 8.5 (requires `ext-uri`). Autoload via PSR-4 `VDB\Spider\` from `src/`.
 
 ## Development & Testing Workflow
 
@@ -26,7 +26,7 @@
 - **ALWAYS run `./bin/check` before EVERY commit and before creating/updating ANY pull request**
 - This is the **single source of truth** for validation
 - Runs the complete CI workflow: lint, phpcs (PSR2), phpmd, phan, and phpunit with 100% coverage
-- Uses `./bin/act --matrix php-versions:8.0` to run GitHub Actions locally with the lowest supported PHP version
+- Uses `./bin/act --matrix php-versions:8.5` to run GitHub Actions locally with the only supported PHP version
 - **DO NOT** commit without running `./bin/check` first
 - **DO NOT** run individual static analysis tools (phpcs, phpmd, phan) manually - `./bin/check` runs them all correctly
 
@@ -41,7 +41,7 @@ php -l src/SomeFile.php                 # Syntax check (optional, no deps)
 ./bin/check                             # Full CI validation (required before commit/PR)
 
 # Equivalents (same as ./bin/check)
-./bin/act --matrix php-versions:8.0     # Explicit form of ./bin/check
+./bin/act --matrix php-versions:8.5     # Explicit form of ./bin/check
 ```
 
 ## Testing & Static Analysis
@@ -70,7 +70,7 @@ php -l src/SomeFile.php                 # Syntax check (optional, no deps)
    - Linting (PSR-1/2 compliance)
    - phpcs, phpmd, phan static analysis
    - phpunit with 100% code coverage
-   - All tests on PHP 8.0
+   - All tests on PHP 8.5
 
 3. **If any check fails:**
    - Fix all issues

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-          extensions: dom, pcntl, ast
+          php-version: '8.5'
+          extensions: dom, pcntl, ast, uri
           tools: composer
           coverage: xdebug
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php-versions: [ '8.5' ]
 
     steps:
       - uses: actions/checkout@v6
@@ -23,7 +23,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ast
+          extensions: ast, uri
           coverage: xdebug
 
       - name: Get Composer Cache Directory

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ There a few requirements for a Pull Request to be accepted:
 You can run the full CI pipeline locally using [nektos/act](https://nektosact.com/):
 
 ```bash
-# Fast path: run the full workflow with PHP 8.0 (recommended)
+# Fast path: run the full workflow with PHP 8.5 (recommended)
 ./bin/check
 ```
 
@@ -167,7 +167,7 @@ Or use the underlying act wrapper directly:
 ./bin/act
 
 # Run specific PHP version locally
-./bin/act --matrix php-versions:8.0
+./bin/act --matrix php-versions:8.5
 
 # Run specific job or view available workflows
 ./bin/act -l

--- a/bin/check
+++ b/bin/check
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Quick CI validation script - runs the full workflow with PHP 8.0 only
+# Quick CI validation script - runs the full workflow with PHP 8.5 only
 # This is the minimal fast path for developers to validate before push
 # Usage: ./bin/check [extra options]
 # Examples:
-#   ./bin/check           # Run full workflow with PHP 8.0
+#   ./bin/check           # Run full workflow with PHP 8.5
 #   ./bin/check -v        # Run with verbose output
 #   ./bin/check --pull    # Force pull latest image
 
@@ -12,6 +12,6 @@ set -e
 # Ensure we're in the project root
 cd "$(dirname "$0")/.."
 
-# Always run with PHP 8.0 matrix only (no full matrix)
-echo "🚀 Running CI validation with PHP 8.0..."
-./bin/act -j build --matrix php-versions:8.0 "$@"
+# Always run with PHP 8.5 matrix only (no full matrix)
+echo "🚀 Running CI validation with PHP 8.5..."
+./bin/act -j build --matrix php-versions:8.5 "$@"

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         "source": "https://github.com/matthijsvandenbos/php-spider"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.5",
         "ext-dom": "*",
         "ext-pcntl": "*",
+        "ext-uri": "*",
         "guzzlehttp/guzzle": "^6.0||^7.0||^8.0",
         "symfony/css-selector": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/dom-crawler": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/finder": "^3.0.0||^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
         "symfony/event-dispatcher": "^4.0.0||^5.0.0||^6.0||^7.0||^8.0",
-        "vdb/uri": "^0.3.2",
         "spatie/robots-txt": "^2.0"
     },
     "require-dev": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,10 +229,10 @@ $spider->getDownloader()->addPostFetchFilter(
 
 ### DiscoveredUri (src/Uri/DiscoveredUri.php)
 
-Wrapper around `vdb/uri` that adds crawl depth tracking.
+Wrapper around the native `Uri\Rfc3986\Uri` class (`ext-uri`, PHP >= 8.5) that adds crawl depth tracking.
 
 **Key properties:**
-- `$decorated` - The underlying UriInterface implementation
+- `$decorated` - The underlying `Uri\Rfc3986\Uri` instance
 - `$depthFound` - Integer depth where this URI was discovered
 
 Depth tracking enables:
@@ -241,10 +241,11 @@ Depth tracking enables:
 - Prioritization strategies
 
 **Normalization:**
-URIs are normalized to prevent duplicate crawling of equivalent URLs:
-- Trailing slashes standardized
-- Default ports removed (80 for http, 443 for https)
-- Query parameters sorted (if not filtered out)
+`Uri\Rfc3986\Uri` normalizes URIs as part of parsing them (per RFC 3986), so no separate
+normalization step is needed to prevent duplicate crawling of equivalent URLs:
+- Scheme and host case are folded to lowercase
+- Dot segments (`.` and `..`) in the path are resolved
+- Percent-encoding is normalized (unreserved characters decoded, hex digits upper-cased)
 
 ## Resource Model
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -26,7 +26,6 @@ Extract links from JSON API responses:
 use VDB\Spider\Discoverer\DiscovererInterface;
 use VDB\Spider\Resource;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Uri;
 
 class JsonApiDiscoverer implements DiscovererInterface
 {
@@ -67,9 +66,8 @@ class JsonApiDiscoverer implements DiscovererInterface
         
         foreach ($links as $link) {
             try {
-                $uri = new Uri($link);
-                $discoveredUris[] = new DiscoveredUri($uri, $currentDepth + 1);
-            } catch (\Exception $e) {
+                $discoveredUris[] = new DiscoveredUri($link, $currentDepth + 1);
+            } catch (\Uri\InvalidUriException $e) {
                 // Skip invalid URIs
                 continue;
             }
@@ -109,7 +107,6 @@ Parse sitemap XML files:
 use VDB\Spider\Discoverer\DiscovererInterface;
 use VDB\Spider\Resource;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Uri;
 
 class SitemapDiscoverer implements DiscovererInterface
 {
@@ -132,8 +129,7 @@ class SitemapDiscoverer implements DiscovererInterface
             $discoveredUris = [];
             
             foreach ($urls as $url) {
-                $uri = new Uri((string)$url);
-                $discoveredUris[] = new DiscoveredUri($uri, $currentDepth + 1);
+                $discoveredUris[] = new DiscoveredUri((string)$url, $currentDepth + 1);
             }
             
             return $discoveredUris;
@@ -156,7 +152,7 @@ Skip URIs with specific file extensions:
 
 ```php
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 class FileExtensionFilter implements PreFetchFilterInterface
 {
@@ -171,7 +167,7 @@ class FileExtensionFilter implements PreFetchFilterInterface
         );
     }
     
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         $path = $uri->getPath();
         $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
@@ -196,7 +192,7 @@ Skip URIs matching specific patterns:
 
 ```php
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 class UrlPatternFilter implements PreFetchFilterInterface
 {
@@ -207,7 +203,7 @@ class UrlPatternFilter implements PreFetchFilterInterface
         $this->excludePatterns = $excludePatterns;
     }
     
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         $url = $uri->toString();
         
@@ -241,7 +237,7 @@ Different max depths for different domains:
 
 ```php
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 class DomainDepthFilter implements PreFetchFilterInterface
 {
@@ -254,17 +250,12 @@ class DomainDepthFilter implements PreFetchFilterInterface
         $this->defaultMaxDepth = $defaultMaxDepth;
     }
     
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         $host = $uri->getHost();
         $maxDepth = $this->domainDepths[$host] ?? $this->defaultMaxDepth;
         
-        // DiscoveredUri has depth tracking
-        if ($uri instanceof \VDB\Spider\Uri\DiscoveredUri) {
-            return $uri->getDepthFound() > $maxDepth;
-        }
-        
-        return false;
+        return $uri->getDepthFound() > $maxDepth;
     }
 }
 ```

--- a/example/lib/Example/LogHandler.php
+++ b/example/lib/Example/LogHandler.php
@@ -41,7 +41,6 @@ namespace Example;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use VDB\Uri\UriInterface;
 use VDB\Spider\Event\SpiderEvents;
 
 class LogHandler implements EventSubscriberInterface

--- a/example/lib/Example/StatsHandler.php
+++ b/example/lib/Example/StatsHandler.php
@@ -37,7 +37,7 @@ namespace Example;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use VDB\Spider\Event\SpiderEvents;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 class StatsHandler implements EventSubscriberInterface
 {
@@ -116,7 +116,7 @@ class StatsHandler implements EventSubscriberInterface
     /**
      * Get all URIs that were added to the queue
      * 
-     * @return UriInterface[]
+     * @return DiscoveredUri[]
      */
     public function getQueued(): array
     {
@@ -126,7 +126,7 @@ class StatsHandler implements EventSubscriberInterface
     /**
      * Get all resources that were successfully persisted
      * 
-     * @return UriInterface[]
+     * @return DiscoveredUri[]
      */
     public function getPersisted(): array
     {

--- a/src/Discoverer/CrawlerDiscoverer.php
+++ b/src/Discoverer/CrawlerDiscoverer.php
@@ -3,13 +3,10 @@ namespace VDB\Spider\Discoverer;
 
 /* @phan-file-suppress PhanUnreferencedUseNormal */
 use DOMElement;
-use ErrorException;
 use Symfony\Component\DomCrawler\Crawler;
+use Uri\InvalidUriException;
 use VDB\Spider\Resource;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Http;
-use VDB\Uri\Uri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -36,7 +33,6 @@ abstract class CrawlerDiscoverer extends Discoverer implements DiscovererInterfa
     /**
      * @param Resource $resource
      * @return DiscoveredUri[]
-     * @throws ErrorException
      */
     public function discover(Resource $resource): array
     {
@@ -45,17 +41,12 @@ abstract class CrawlerDiscoverer extends Discoverer implements DiscovererInterfa
         $uris = array();
         foreach ($crawler as $node) {
             try {
-                $baseUri = $resource->getUri()->toString();
                 // @phan-suppress-next-line PhanUndeclaredMethod - Symfony DomCrawler returns DOMElement instances
                 $href = $node->getAttribute('href');
                 $depthFound = $resource->getUri()->getDepthFound() + 1;
 
-                if (substr($href, 0, 4) === "http") {
-                    $uris[] = new DiscoveredUri(new Http($href, $baseUri), $depthFound);
-                } else {
-                    $uris[] = new DiscoveredUri(new Uri($href, $baseUri), $depthFound);
-                }
-            } catch (UriSyntaxException $e) {
+                $uris[] = new DiscoveredUri($resource->getUri()->resolve($href), $depthFound);
+            } catch (InvalidUriException $e) {
                 // do nothing. We simply ignore invalid URIs, since we don't control what we crawl.
             }
         }

--- a/src/Discoverer/DiscovererSet.php
+++ b/src/Discoverer/DiscovererSet.php
@@ -44,7 +44,7 @@ class DiscovererSet implements DiscovererSetInterface
      */
     private function markSeen(DiscoveredUri $uri): void
     {
-        $uriString = $uri->normalize()->toString();
+        $uriString = $uri->toString();
         if (!array_key_exists($uriString, $this->alreadySeenUris)) {
             $this->alreadySeenUris[$uriString] = $uri->getDepthFound();
         }
@@ -77,7 +77,6 @@ class DiscovererSet implements DiscovererSetInterface
             $discoveredUris = array_merge($discoveredUris, $discoverer->discover($resource));
         }
 
-        $this->normalize($discoveredUris);
         $this->removeDuplicates($discoveredUris);
         $this->filterAlreadySeen($discoveredUris);
         $this->filter($discoveredUris);
@@ -155,18 +154,6 @@ class DiscovererSet implements DiscovererSetInterface
     {
         $this->maxDepth = $depth;
         return $this;
-    }
-
-    /**
-     * Normalizes all discovered URIs.
-     *
-     * @param DiscoveredUri[] $discoveredUris
-     */
-    private function normalize(array &$discoveredUris): void
-    {
-        foreach ($discoveredUris as $k => $uri) {
-            $discoveredUris[$k] = $uri->normalize();
-        }
     }
 
     /**

--- a/src/Filter/PreFetchFilterInterface.php
+++ b/src/Filter/PreFetchFilterInterface.php
@@ -2,7 +2,7 @@
 
 namespace VDB\Spider\Filter;
 
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -11,8 +11,8 @@ interface PreFetchFilterInterface
 {
     /**
      * Returns true of the URI should be filtered out, i.e. NOT be crawled.
-     * @param UriInterface $uri
+     * @param DiscoveredUri $uri
      * @return boolean
      */
-    public function match(UriInterface $uri): bool;
+    public function match(DiscoveredUri $uri): bool;
 }

--- a/src/Filter/Prefetch/AllowedHostsFilter.php
+++ b/src/Filter/Prefetch/AllowedHostsFilter.php
@@ -3,7 +3,7 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -36,7 +36,7 @@ class AllowedHostsFilter implements PreFetchFilterInterface
         }
     }
 
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         $currentHostname = $uri->getHost();
 

--- a/src/Filter/Prefetch/AllowedPortsFilter.php
+++ b/src/Filter/Prefetch/AllowedPortsFilter.php
@@ -3,7 +3,7 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -24,7 +24,7 @@ class AllowedPortsFilter implements PreFetchFilterInterface
         $this->allowedPorts = $allowedPorts;
     }
 
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         return !in_array($uri->getPort(), $this->allowedPorts);
     }

--- a/src/Filter/Prefetch/AllowedSchemeFilter.php
+++ b/src/Filter/Prefetch/AllowedSchemeFilter.php
@@ -3,7 +3,7 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -21,10 +21,10 @@ class AllowedSchemeFilter implements PreFetchFilterInterface
     }
 
     /**
-     * @param UriInterface $uri
+     * @param DiscoveredUri $uri
      * @return bool
      */
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         return !in_array($uri->getScheme(), $this->allowedSchemes);
     }

--- a/src/Filter/Prefetch/CachedResourceFilter.php
+++ b/src/Filter/Prefetch/CachedResourceFilter.php
@@ -4,7 +4,7 @@ namespace VDB\Spider\Filter\Prefetch;
 
 use InvalidArgumentException;
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * Filter to skip downloading resources that are already cached and younger than max age.
@@ -44,10 +44,10 @@ class CachedResourceFilter implements PreFetchFilterInterface
     /**
      * Returns true if the URI should be filtered out (already cached and fresh).
      *
-     * @param UriInterface $uri
+     * @param DiscoveredUri $uri
      * @return bool
      */
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         // Build the file path for the URI
         $hostname = $uri->getHost();

--- a/src/Filter/Prefetch/RestrictToBaseUriFilter.php
+++ b/src/Filter/Prefetch/RestrictToBaseUriFilter.php
@@ -2,12 +2,11 @@
 
 namespace VDB\Spider\Filter\Prefetch;
 
-use ErrorException;
 use InvalidArgumentException;
+use Uri\InvalidUriException;
+use Uri\Rfc3986\Uri;
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -24,12 +23,12 @@ class RestrictToBaseUriFilter implements PreFetchFilterInterface
     {
         try {
             $this->seed = new Uri($seed);
-        } catch (ErrorException | UriSyntaxException $e) {
+        } catch (InvalidUriException $e) {
             throw new InvalidArgumentException("Invalid seed: " . $e->getMessage());
         }
     }
 
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         /*
          * if the URI does not contain the seed, it is not allowed

--- a/src/Filter/Prefetch/RobotsTxtDisallowFilter.php
+++ b/src/Filter/Prefetch/RobotsTxtDisallowFilter.php
@@ -2,21 +2,20 @@
 
 namespace VDB\Spider\Filter\Prefetch;
 
-use ErrorException;
 use Exception;
 use Spatie\Robots\RobotsTxt;
+use Uri\Rfc3986\Uri;
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\FileUri;
-use VDB\Uri\Http;
-use VDB\Uri\Uri;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
  */
 class RobotsTxtDisallowFilter implements PreFetchFilterInterface
 {
+    private const FILE_SCHEMES = ['file'];
+    private const HTTP_SCHEMES = ['http', 'https'];
+
     private RobotsTxt $parser;
     private ?string $userAgent;
     private Uri $seedUri;
@@ -24,13 +23,10 @@ class RobotsTxtDisallowFilter implements PreFetchFilterInterface
     /**
      * @param string $seedUrl The robots.txt file will be loaded from this domain.
      * @param string|null $userAgent
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function __construct(string $seedUrl, ?string $userAgent = null)
     {
         $this->seedUri = new Uri($seedUrl);
-        $this->seedUri->normalize();
         $this->userAgent = $userAgent;
         $this->parser = new RobotsTxt(self::fetchRobotsTxt(self::extractRobotsTxtUri($seedUrl)));
     }
@@ -55,29 +51,26 @@ class RobotsTxtDisallowFilter implements PreFetchFilterInterface
      *
      * @param string $seedUrl
      * @return string
-     *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     private static function extractRobotsTxtUri(string $seedUrl): string
     {
         $uri = new Uri($seedUrl);
-        if (in_array($uri->getScheme(), FileUri::$allowedSchemes)) {
-            return (new FileUri($seedUrl . '/robots.txt'))->toString();
-        } elseif (in_array($uri->getScheme(), Http::$allowedSchemes)) {
-            return $uri->toBaseUri()->toString() . '/robots.txt';
+        if (in_array($uri->getScheme(), self::FILE_SCHEMES, true)) {
+            return (new Uri($seedUrl . '/robots.txt'))->toString();
+        } elseif (in_array($uri->getScheme(), self::HTTP_SCHEMES, true)) {
+            return $uri->withPath('/robots.txt')->withQuery(null)->withFragment(null)->toString();
         } else {
             throw new ExtractRobotsTxtException(
                 "Seed URL scheme must be one of " .
-                implode(', ', array_merge(FileUri::$allowedSchemes, Http::$allowedSchemes))
+                implode(', ', array_merge(self::FILE_SCHEMES, self::HTTP_SCHEMES))
             );
         }
     }
 
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         // Make the uri relative to $this->seedUri, so it will match with the rules in the robots.txt
-        $relativeUri = str_replace($this->seedUri->toString(), '', $uri->normalize()->toString());
+        $relativeUri = str_replace($this->seedUri->toString(), '', $uri->toString());
         return !$this->parser->allows($relativeUri, $this->userAgent);
     }
 }

--- a/src/Filter/Prefetch/UriFilter.php
+++ b/src/Filter/Prefetch/UriFilter.php
@@ -3,7 +3,7 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
@@ -20,7 +20,7 @@ class UriFilter implements PreFetchFilterInterface
         $this->regexes = $regexes;
     }
 
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         foreach ($this->regexes as $regex) {
             if (preg_match($regex, $uri->toString())) {

--- a/src/Filter/Prefetch/UriWithHashFragmentFilter.php
+++ b/src/Filter/Prefetch/UriWithHashFragmentFilter.php
@@ -3,14 +3,14 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
  */
 class UriWithHashFragmentFilter implements PreFetchFilterInterface
 {
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         return null !== $uri->getFragment();
     }

--- a/src/Filter/Prefetch/UriWithQueryStringFilter.php
+++ b/src/Filter/Prefetch/UriWithQueryStringFilter.php
@@ -3,14 +3,14 @@
 namespace VDB\Spider\Filter\Prefetch;
 
 use VDB\Spider\Filter\PreFetchFilterInterface;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * @author Matthijs van den Bos <matthijs@vandenbos.org>
  */
 class UriWithQueryStringFilter implements PreFetchFilterInterface
 {
-    public function match(UriInterface $uri): bool
+    public function match(DiscoveredUri $uri): bool
     {
         return null !== $uri->getQuery();
     }

--- a/src/Spider.php
+++ b/src/Spider.php
@@ -2,9 +2,10 @@
 
 namespace VDB\Spider;
 
-use Exception;
 use InvalidArgumentException;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Uri\InvalidUriException;
+use Uri\Rfc3986\Uri;
 use VDB\Spider\Discoverer\DiscovererInterface;
 use VDB\Spider\Discoverer\DiscovererSet;
 use VDB\Spider\Discoverer\DiscovererSetInterface;
@@ -19,7 +20,6 @@ use VDB\Spider\PersistenceHandler\PersistenceHandlerInterface;
 use VDB\Spider\QueueManager\InMemoryQueueManager;
 use VDB\Spider\QueueManager\QueueManagerInterface;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Http;
 
 class Spider
 {
@@ -72,11 +72,14 @@ class Spider
             throw new InvalidArgumentException("Empty seed");
         }
         try {
-            $seed = new Http($uri);
-            $this->seed = new DiscoveredUri($seed->normalize(), 0);
-        } catch (Exception $e) {
+            $seed = new Uri($uri);
+        } catch (InvalidUriException $e) {
             throw new InvalidArgumentException("Invalid seed: " . $e->getMessage());
         }
+        if (!in_array($seed->getScheme(), ['http', 'https'], true)) {
+            throw new InvalidArgumentException("Invalid seed: seed must use the http or https scheme");
+        }
+        $this->seed = new DiscoveredUri($seed, 0);
     }
 
     private function setSpiderId(?string $spiderId): void

--- a/src/Uri/DiscoveredUri.php
+++ b/src/Uri/DiscoveredUri.php
@@ -2,23 +2,17 @@
 
 namespace VDB\Spider\Uri;
 
-use ErrorException;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
-use VDB\Uri\UriInterface;
+use Uri\Rfc3986\Uri;
+use Uri\UriComparisonMode;
 
-class DiscoveredUri implements UriInterface
+class DiscoveredUri
 {
-    protected string|UriInterface $decorated;
+    protected Uri $decorated;
     private int $depthFound;
 
-    /**
-     * @throws ErrorException
-     * @throws UriSyntaxException
-     */
-    public function __construct(UriInterface|string $decorated, int $depthFound)
+    public function __construct(Uri|string $decorated, int $depthFound)
     {
-        if (!$decorated instanceof UriInterface) {
+        if (!$decorated instanceof Uri) {
             $decorated = new Uri($decorated);
         }
 
@@ -44,95 +38,62 @@ class DiscoveredUri implements UriInterface
         return $this->decorated->toString();
     }
 
-    /**
-     * @param UriInterface $that
-     * @param boolean $normalized whether to compare normalized versions of the URIs
-     * @return boolean
-     */
-    public function equals(UriInterface $that, $normalized = false): bool
+    public function equals(DiscoveredUri $that): bool
     {
-        return $this->decorated->equals($that, $normalized);
+        return $this->decorated->equals($that->decorated, UriComparisonMode::IncludeFragment);
     }
 
     /**
-     * @return UriInterface
+     * Resolves an (absolute or relative) URI reference against this Uri.
      */
-    public function normalize(): UriInterface
+    public function resolve(string $uri): Uri
     {
-        // This normalizes the decorated Uri in place. We don't want to return the decorated Uri, but $this.
-        $this->decorated->normalize();
-        return $this;
+        return $this->decorated->resolve($uri);
     }
 
     /**
-     * Alias of Uri::toString()
-     *
-     * @return string
+     * Alias of DiscoveredUri::toString()
      */
     public function __toString(): string
     {
-        return $this->decorated->__toString();
+        return $this->decorated->toString();
     }
 
-    /**
-     * @return string|null
-     */
     public function getHost(): ?string
     {
         return $this->decorated->getHost();
     }
 
-    /**
-     * @return string|null
-     */
     public function getPassword(): ?string
     {
         return $this->decorated->getPassword();
     }
 
-    /**
-     * @return string
-     */
     public function getPath(): string
     {
-        return $this->decorated->getPath() ?: '';
+        return $this->decorated->getPath();
     }
 
-    /**
-     * @return int|null
-     */
     public function getPort(): ?int
     {
         return $this->decorated->getPort();
     }
 
-    /**
-     * @return string|null
-     */
     public function getQuery(): ?string
     {
         return $this->decorated->getQuery();
     }
 
-    /**
-     * @return string|null
-     */
     public function getScheme(): ?string
     {
         return $this->decorated->getScheme();
     }
 
-    /**
-     * @return string|null
-     */
     public function getUsername(): ?string
     {
         return $this->decorated->getUsername();
     }
 
-    /**
-     * @return string|null
-     */
     public function getFragment(): ?string
     {
         return $this->decorated->getFragment();

--- a/tests/Discoverer/DiscovererSetTest.php
+++ b/tests/Discoverer/DiscovererSetTest.php
@@ -11,7 +11,6 @@
 
 namespace VDB\Spider\Tests\Discoverer;
 
-use ErrorException;
 use Exception;
 use VDB\Spider\Discoverer\DiscovererSet;
 use VDB\Spider\Discoverer\XPathExpressionDiscoverer;
@@ -20,8 +19,6 @@ use VDB\Spider\Filter\Prefetch\AllowedPortsFilter;
 use VDB\Spider\Filter\Prefetch\RobotsTxtDisallowFilter;
 use VDB\Spider\Filter\Prefetch\UriFilter;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\FileUri;
 
 /**
  *
@@ -115,8 +112,6 @@ class DiscovererSetTest extends DiscovererTestCase
      * @covers \VDB\Spider\Discoverer\DiscovererSet
      * @covers \VDB\Spider\Filter\Prefetch\RobotsTxtDisallowFilter
      *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @throws Exception
      */
     public function testRobotsTxtDisallowFilter()
@@ -133,7 +128,7 @@ class DiscovererSetTest extends DiscovererTestCase
 
         $uris = $discovererSet->discover($spiderResource);
         $this->assertCount(1, $uris);
-        $this->assertNotContains((new FileUri($uriInBody2))->toString(), array_map(fn($uri): string => (new FileUri($uri->toString()))->toString(), $uris));
+        $this->assertNotContains($uriInBody2, array_map(fn($uri): string => $uri->toString(), $uris));
     }
 
     /**
@@ -166,8 +161,6 @@ class DiscovererSetTest extends DiscovererTestCase
     }
 
     /**
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @throws Exception
      */
     public function testInvalidUriSkipped()
@@ -186,8 +179,6 @@ class DiscovererSetTest extends DiscovererTestCase
     }
 
     /**
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @throws Exception
      */
     public function testDuplicatesRemoved()

--- a/tests/Discoverer/DiscovererTestCase.php
+++ b/tests/Discoverer/DiscovererTestCase.php
@@ -13,14 +13,12 @@ namespace VDB\Spider\Tests\Discoverer;
 
 use DOMDocument;
 use DomElement;
-use ErrorException;
 use Exception;
 use GuzzleHttp\Psr7\Response;
 use VDB\Spider\Discoverer\DiscovererInterface;
 use VDB\Spider\Resource;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 abstract class DiscovererTestCase extends TestCase
 {
@@ -34,8 +32,6 @@ abstract class DiscovererTestCase extends TestCase
     protected string $resourceContent;
 
     /**
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @throws Exception
      */
     protected function setUp(): void

--- a/tests/Downloader/DownloaderTest.php
+++ b/tests/Downloader/DownloaderTest.php
@@ -18,7 +18,6 @@ use VDB\Spider\Resource;
 use VDB\Spider\Tests\Helpers\ResourceBuilder;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Uri;
 
 /**
  *
@@ -64,23 +63,19 @@ class DownloaderTest extends TestCase
     /**
      * @covers \VDB\Spider\Downloader\Downloader
      *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @covers \VDB\Spider\Downloader\Downloader::download
      * @covers \VDB\Spider\Downloader\Downloader::fetchResource
      * @covers \VDB\Spider\Downloader\Downloader::dispatch
      */
     public function testDownload()
     {
-        $resource = $this->downloader->download(new DiscoveredUri(new Uri('http://foobar.org'), 0));
+        $resource = $this->downloader->download(new DiscoveredUri('http://foobar.org', 0));
         $this->assertInstanceOf('VDB\\Spider\\Resource', $resource);
     }
 
     /**
      * @covers \VDB\Spider\Downloader\Downloader
      *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @covers \VDB\Spider\Downloader\Downloader::download
      * @covers \VDB\Spider\Downloader\Downloader::fetchResource
      * @covers \VDB\Spider\Downloader\Downloader::dispatch
@@ -94,7 +89,7 @@ class DownloaderTest extends TestCase
             ->will($this->throwException(new Exception));
         $this->downloader->setRequestHandler($requestHandler);
 
-        $resource = $this->downloader->download(new DiscoveredUri(new Uri('http://foobar.org'), 0));
+        $resource = $this->downloader->download(new DiscoveredUri('http://foobar.org', 0));
 
         $this->assertFalse($resource);
     }
@@ -102,8 +97,6 @@ class DownloaderTest extends TestCase
     /**
      * @covers \VDB\Spider\Downloader\Downloader
      *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @covers \VDB\Spider\Downloader\Downloader::addPostFetchFilter
      * @covers \VDB\Spider\Downloader\Downloader::download
      * @covers \VDB\Spider\Downloader\Downloader::matchesPostfetchFilter
@@ -117,7 +110,7 @@ class DownloaderTest extends TestCase
             ->will($this->returnValue(false));
         $this->downloader->addPostFetchFilter($filterNeverMatch);
 
-        $resource = $this->downloader->download(new DiscoveredUri(new Uri('http://foobar.org'), 0));
+        $resource = $this->downloader->download(new DiscoveredUri('http://foobar.org', 0));
 
         $this->assertInstanceOf('VDB\\Spider\\Resource', $resource);
     }
@@ -125,8 +118,6 @@ class DownloaderTest extends TestCase
     /**
      * @covers \VDB\Spider\Downloader\Downloader
      *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      * @covers \VDB\Spider\Downloader\Downloader::setDownloadLimit
      * @covers \VDB\Spider\Downloader\Downloader::download
      * @covers \VDB\Spider\Downloader\Downloader::isDownLoadLimitExceeded
@@ -152,7 +143,7 @@ class DownloaderTest extends TestCase
             ->will($this->returnValue(true));
         $downloader = new Downloader(null, null, [$filterAlwaysMatch]);
 
-        $resource = $downloader->download(new DiscoveredUri(new Uri('http://foobar.org'), 0));
+        $resource = $downloader->download(new DiscoveredUri('http://foobar.org', 0));
 
         $this->assertFalse($resource);
     }
@@ -224,7 +215,7 @@ class DownloaderTest extends TestCase
         
         $downloader->addPostFetchFilter($filterAlwaysMatch);
 
-        $resource = $downloader->download(new DiscoveredUri(new Uri('http://foobar.org'), 0));
+        $resource = $downloader->download(new DiscoveredUri('http://foobar.org', 0));
 
         $this->assertFalse($resource);
     }

--- a/tests/EventListener/PolitenessPolicyListenerTest.php
+++ b/tests/EventListener/PolitenessPolicyListenerTest.php
@@ -11,10 +11,10 @@
 namespace VDB\Spider\Tests\EventListener;
 
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Uri\Rfc3986\Uri;
 use VDB\Spider\Event\SpiderEvents;
 use VDB\Spider\EventListener\PolitenessPolicyListener;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
 
 /**
  *
@@ -28,7 +28,7 @@ class PolitenessPolicyListenerTest extends TestCase
     {
         $politenessPolicyListener = new PolitenessPolicyListener(500);
 
-        $uri = new Uri('http://php-spider.org/', 'http://php-spider.org/');
+        $uri = new Uri('http://php-spider.org/');
         $event = new GenericEvent(SpiderEvents::SPIDER_CRAWL_PRE_REQUEST, array('uri' => $uri));
 
         $politenessPolicyListener->onCrawlPreRequest($event);
@@ -47,10 +47,10 @@ class PolitenessPolicyListenerTest extends TestCase
     {
         $politenessPolicyListener = new PolitenessPolicyListener(500);
 
-        $uri = new Uri('http://php-spider.org/', 'http://php-spider.org/');
+        $uri = new Uri('http://php-spider.org/');
         $event = new GenericEvent(SpiderEvents::SPIDER_CRAWL_PRE_REQUEST, array('uri' => $uri));
 
-        $uri2 = new Uri('http://example.com/', 'http://example.com/');
+        $uri2 = new Uri('http://example.com/');
         $event2 = new GenericEvent(SpiderEvents::SPIDER_CRAWL_PRE_REQUEST, array('uri' => $uri2));
 
         $politenessPolicyListener->onCrawlPreRequest($event);

--- a/tests/Filter/Prefetch/AllowedHostsFilterTest.php
+++ b/tests/Filter/Prefetch/AllowedHostsFilterTest.php
@@ -13,7 +13,7 @@ namespace VDB\Spider\Tests\Filter\Prefetch;
 
 use VDB\Spider\Filter\Prefetch\AllowedHostsFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -27,9 +27,9 @@ class AllowedHostsFilterTest extends TestCase
     {
         $filter = new AllowedHostsFilter(array('http://blog.php-spider.org'));
 
-        $uri1 = new Uri('http://example.org');
-        $uri2 = new Uri('http://php-spider.org');
-        $uri3 = new Uri('http://blog.php-spider.org');
+        $uri1 = new DiscoveredUri('http://example.org', 0);
+        $uri2 = new DiscoveredUri('http://php-spider.org', 0);
+        $uri3 = new DiscoveredUri('http://blog.php-spider.org', 0);
 
         $this->assertTrue($filter->match($uri1));
         $this->assertTrue($filter->match($uri2));
@@ -43,10 +43,10 @@ class AllowedHostsFilterTest extends TestCase
     {
         $filter = new AllowedHostsFilter(array('http://blog.php-spider.org'), true);
 
-        $uri1 = new Uri('http://example.com');
-        $uri2 = new Uri('http://blog.php-spider.org');
-        $uri3 = new Uri('http://test.php-spider.org');
-        $uri4 = new Uri('http://php-spider.org');
+        $uri1 = new DiscoveredUri('http://example.com', 0);
+        $uri2 = new DiscoveredUri('http://blog.php-spider.org', 0);
+        $uri3 = new DiscoveredUri('http://test.php-spider.org', 0);
+        $uri4 = new DiscoveredUri('http://php-spider.org', 0);
 
         $this->assertTrue($filter->match($uri1));
         $this->assertFalse($filter->match($uri2));
@@ -61,12 +61,12 @@ class AllowedHostsFilterTest extends TestCase
     {
         $filter = new AllowedHostsFilter(array('http://blog.php-spider.org', 'http://example.com'), true);
 
-        $uri1 = new Uri('http://example.com');
-        $uri2 = new Uri('http://test.example.com');
-        $uri3 = new Uri('http://blog.php-spider.org');
-        $uri4 = new Uri('http://test.php-spider.org');
-        $uri5 = new Uri('http://php-spider.org');
-        $uri6 = new Uri('http://example.org');
+        $uri1 = new DiscoveredUri('http://example.com', 0);
+        $uri2 = new DiscoveredUri('http://test.example.com', 0);
+        $uri3 = new DiscoveredUri('http://blog.php-spider.org', 0);
+        $uri4 = new DiscoveredUri('http://test.php-spider.org', 0);
+        $uri5 = new DiscoveredUri('http://php-spider.org', 0);
+        $uri6 = new DiscoveredUri('http://example.org', 0);
 
         $this->assertFalse($filter->match($uri1));
         $this->assertFalse($filter->match($uri2));

--- a/tests/Filter/Prefetch/AllowedPortsFilterTest.php
+++ b/tests/Filter/Prefetch/AllowedPortsFilterTest.php
@@ -13,7 +13,7 @@ namespace VDB\Spider\Tests\Filter\Prefetch;
 
 use VDB\Spider\Filter\Prefetch\AllowedPortsFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -27,9 +27,9 @@ class AllowedPortsFilterTest extends TestCase
     {
         $filter = new AllowedPortsFilter(array(8080));
 
-        $uri1 = new Uri('http://example.org');
-        $uri2 = new Uri('http://php-spider.org:8080');
-        $uri3 = new Uri('http://blog.php-spider.org');
+        $uri1 = new DiscoveredUri('http://example.org', 0);
+        $uri2 = new DiscoveredUri('http://php-spider.org:8080', 0);
+        $uri3 = new DiscoveredUri('http://blog.php-spider.org', 0);
 
         $this->assertTrue($filter->match($uri1));
         $this->assertFalse($filter->match($uri2));

--- a/tests/Filter/Prefetch/AllowedSchemeFilterTest.php
+++ b/tests/Filter/Prefetch/AllowedSchemeFilterTest.php
@@ -13,7 +13,7 @@ namespace VDB\Spider\Tests\Filter\Prefetch;
 
 use VDB\Spider\Filter\Prefetch\AllowedSchemeFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -27,11 +27,11 @@ class AllowedSchemeFilterTest extends TestCase
     {
         $filter = new AllowedSchemeFilter(array('http'));
 
-        $currentUri = 'http://php-spider.org';
-        $uri =  new Uri('http://php-spider.org');
-        $uri2 = new Uri('https://php-spider.org');
-        $uri3 = new Uri('#', $currentUri);
-        $uri4 = new Uri('mailto:info@example.org');
+        $currentUri = new DiscoveredUri('http://php-spider.org', 0);
+        $uri =  new DiscoveredUri('http://php-spider.org', 0);
+        $uri2 = new DiscoveredUri('https://php-spider.org', 0);
+        $uri3 = new DiscoveredUri($currentUri->resolve('#'), 0);
+        $uri4 = new DiscoveredUri('mailto:info@example.org', 0);
 
         $this->assertFalse($filter->match($uri), 'HTTP scheme filtered');
         $this->assertTrue($filter->match($uri2), 'HTTPS scheme filtered');

--- a/tests/Filter/Prefetch/CachedResourceFilterTest.php
+++ b/tests/Filter/Prefetch/CachedResourceFilterTest.php
@@ -14,7 +14,7 @@ namespace VDB\Spider\Tests\Filter\Prefetch;
 use InvalidArgumentException;
 use VDB\Spider\Filter\Prefetch\CachedResourceFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  * Test for CachedResourceFilter
@@ -50,7 +50,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchReturnsFalseWhenFileDoesNotExist()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
 
         $this->assertFalse($filter->match($uri));
     }
@@ -62,7 +62,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchReturnsTrueWhenFileExistsAndIsFresh()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
         
         // Create the cached file
         $this->createCachedFile($uri, 'test content');
@@ -77,7 +77,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchReturnsFalseWhenFileIsExpired()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 10);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
         
         // Create the cached file and modify its timestamp to be older than maxAge
         $filePath = $this->createCachedFile($uri, 'test content');
@@ -93,7 +93,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchReturnsTrueWhenMaxAgeIsZero()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 0);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
         
         // Create the cached file with an old timestamp
         $filePath = $this->createCachedFile($uri, 'test content');
@@ -110,7 +110,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchHandlesIndexFiles()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/');
+        $uri = new DiscoveredUri('http://example.com/', 0);
 
         // Create the cached file (should be stored as index.html)
         $this->createCachedFile($uri, 'test content');
@@ -125,7 +125,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchHandlesRootWithoutTrailingSlash()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com');
+        $uri = new DiscoveredUri('http://example.com', 0);
 
         // Create the cached file (should be stored as index.html for empty path)
         $this->createCachedFile($uri, 'test content');
@@ -140,7 +140,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchHandlesDirectoryWithTrailingSlash()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/subdir/');
+        $uri = new DiscoveredUri('http://example.com/subdir/', 0);
         
         // Create the cached file (should be stored as index.html in subdir)
         $this->createCachedFile($uri, 'test content');
@@ -155,7 +155,7 @@ class CachedResourceFilterTest extends TestCase
     public function testMatchHandlesSpecialCharactersInFilename()
     {
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/file with spaces.html');
+        $uri = new DiscoveredUri('http://example.com/file%20with%20spaces.html', 0);
         
         // Create the cached file (filename should be URL-encoded)
         $this->createCachedFile($uri, 'test content');
@@ -175,7 +175,7 @@ class CachedResourceFilterTest extends TestCase
         $filter1 = new CachedResourceFilter($this->testCacheDir, $spiderId1, 3600);
         $filter2 = new CachedResourceFilter($this->testCacheDir, $spiderId2, 3600);
         
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
         
         // Create cached file for spider-1
         $this->createCachedFileWithSpiderId($uri, 'test content', $spiderId1);
@@ -195,7 +195,7 @@ class CachedResourceFilterTest extends TestCase
     {
         $maxAge = 10;
         $filter = new CachedResourceFilter($this->testCacheDir, $this->testSpiderId, $maxAge);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
         
         // Create the cached file and set it exactly at max age
         $filePath = $this->createCachedFile($uri, 'test content');
@@ -214,7 +214,7 @@ class CachedResourceFilterTest extends TestCase
         // Test that constructor properly handles basePath with trailing slash
         $basePathWithSlash = $this->testCacheDir . DIRECTORY_SEPARATOR;
         $filter = new CachedResourceFilter($basePathWithSlash, $this->testSpiderId, 3600);
-        $uri = new Uri('http://example.com/page.html');
+        $uri = new DiscoveredUri('http://example.com/page.html', 0);
 
         // Create the cached file
         $this->createCachedFile($uri, 'test content');
@@ -238,7 +238,7 @@ class CachedResourceFilterTest extends TestCase
     /**
      * Helper method to create a cached file for testing
      */
-    private function createCachedFile(Uri $uri, string $content): string
+    private function createCachedFile(DiscoveredUri $uri, string $content): string
     {
         return $this->createCachedFileWithSpiderId($uri, $content, $this->testSpiderId);
     }
@@ -246,7 +246,7 @@ class CachedResourceFilterTest extends TestCase
     /**
      * Helper method to create a cached file with a specific spider ID
      */
-    private function createCachedFileWithSpiderId(Uri $uri, string $content, string $spiderId): string
+    private function createCachedFileWithSpiderId(DiscoveredUri $uri, string $content, string $spiderId): string
     {
         $hostname = $uri->getHost();
         $path = $uri->getPath() ?: '';

--- a/tests/Filter/Prefetch/RestrictToBaseUriFilterTest.php
+++ b/tests/Filter/Prefetch/RestrictToBaseUriFilterTest.php
@@ -13,7 +13,7 @@ namespace VDB\Spider\Tests\Filter\Prefetch;
 
 use VDB\Spider\Filter\Prefetch\RestrictToBaseUriFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -37,7 +37,7 @@ class RestrictToBaseUriFilterTest extends TestCase
     {
         $filter = new RestrictToBaseUriFilter('http://php-spider.org');
 
-        $uri = new Uri($href);
+        $uri = new DiscoveredUri($href, 0);
 
         $this->assertEquals($expected, $filter->match($uri));
     }

--- a/tests/Filter/Prefetch/RobotsTxtDisallowFilterTest.php
+++ b/tests/Filter/Prefetch/RobotsTxtDisallowFilterTest.php
@@ -15,8 +15,7 @@ use VDB\Spider\Filter\Prefetch\ExtractRobotsTxtException;
 use VDB\Spider\Filter\Prefetch\FetchRobotsTxtException;
 use VDB\Spider\Filter\Prefetch\RobotsTxtDisallowFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Http;
-use VDB\Uri\UriInterface;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -48,7 +47,7 @@ class RobotsTxtDisallowFilterTest extends TestCase
      * @covers       \VDB\Spider\Filter\Prefetch\RobotsTxtDisallowFilter
      * @dataProvider userAgentMatchURIProvider
      */
-    public function testUserAgentMatch(UriInterface $href, bool $expected)
+    public function testUserAgentMatch(DiscoveredUri $href, bool $expected)
     {
         $robotsTxtFilter = new RobotsTxtDisallowFilter(seedUrl: "file://" . __DIR__, userAgent: 'PHP-Spider');
         $this->assertEquals($expected, $robotsTxtFilter->match($href));
@@ -58,7 +57,7 @@ class RobotsTxtDisallowFilterTest extends TestCase
      * @covers       \VDB\Spider\Filter\Prefetch\RobotsTxtDisallowFilter
      * @dataProvider noUserAgentMatchURIProvider
      */
-    public function testNoUserAgentMatch(UriInterface $href, bool $expected)
+    public function testNoUserAgentMatch(DiscoveredUri $href, bool $expected)
     {
         $robotsTxtFilter = new RobotsTxtDisallowFilter(seedUrl: "file://" . __DIR__);
         $this->assertEquals($expected, $robotsTxtFilter->match($href));
@@ -67,18 +66,18 @@ class RobotsTxtDisallowFilterTest extends TestCase
     public function noUserAgentMatchURIProvider(): array
     {
         return array(
-            array(new Http('http://example.com'), false),
-            array(new Http('http://example.com/foo'), true),
-            array(new Http('http://example.com/bar'), false),
+            array(new DiscoveredUri('http://example.com', 0), false),
+            array(new DiscoveredUri('http://example.com/foo', 0), true),
+            array(new DiscoveredUri('http://example.com/bar', 0), false),
         );
     }
 
     public function userAgentMatchURIProvider(): array
     {
         return array(
-            array(new Http('http://example.com'), false),
-            array(new Http('http://example.com/foo'), false),
-            array(new Http('http://example.com/bar'), true),
+            array(new DiscoveredUri('http://example.com', 0), false),
+            array(new DiscoveredUri('http://example.com/foo', 0), false),
+            array(new DiscoveredUri('http://example.com/bar', 0), true),
         );
     }
 }

--- a/tests/Filter/Prefetch/UriFilterTest.php
+++ b/tests/Filter/Prefetch/UriFilterTest.php
@@ -11,12 +11,10 @@
 
 namespace VDB\Spider\Tests\Filter\Prefetch;
 
-use ErrorException;
 use VDB\Spider\Filter\Prefetch\RestrictToBaseUriFilter;
 use VDB\Spider\Filter\Prefetch\UriFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -30,14 +28,11 @@ class UriFilterTest extends TestCase
      *
      * @covers       \VDB\Spider\Filter\Prefetch\UriFilter
      * @dataProvider matchURIProvider
-     *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testMatch(array $regexes, string $href, bool $expected)
     {
         $filter = new UriFilter($regexes);
-        $uri = new Uri($href);
+        $uri = new DiscoveredUri($href, 0);
         $this->assertEquals($expected, $filter->match($uri));
     }
 

--- a/tests/Filter/Prefetch/UriWithHashFragmentFilterTest.php
+++ b/tests/Filter/Prefetch/UriWithHashFragmentFilterTest.php
@@ -11,11 +11,9 @@
 
 namespace VDB\Spider\Tests\Filter\Prefetch;
 
-use ErrorException;
 use VDB\Spider\Filter\Prefetch\UriWithHashFragmentFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -24,25 +22,22 @@ class UriWithHashFragmentFilterTest extends TestCase
 {
     /**
      * @covers \VDB\Spider\Filter\Prefetch\UriWithHashFragmentFilter
-     *
-     * @throws UriSyntaxException
-     * @throws ErrorException
      */
     public function testMatch()
     {
         $filter = new UriWithHashFragmentFilter();
 
-        $currentUri = 'http://php-spider.org';
-        $uri1 = new Uri('#', $currentUri);
-        $uri2 = new Uri('#foo', $currentUri);
-        $uri3 = new Uri('http://php-spider.org/foo#bar', $currentUri);
-        $uri4 = new Uri('http://php-spider.org/foo/#bar', $currentUri);
-        $uri5 = new Uri('http://php-spider.org#/foo/bar', $currentUri);
+        $currentUri = new DiscoveredUri('http://php-spider.org', 0);
+        $uri1 = new DiscoveredUri($currentUri->resolve('#'), 0);
+        $uri2 = new DiscoveredUri($currentUri->resolve('#foo'), 0);
+        $uri3 = new DiscoveredUri('http://php-spider.org/foo#bar', 0);
+        $uri4 = new DiscoveredUri('http://php-spider.org/foo/#bar', 0);
+        $uri5 = new DiscoveredUri('http://php-spider.org#/foo/bar', 0);
 
         $this->assertTrue($filter->match($uri1), '# filtered');
         $this->assertTrue($filter->match($uri2), '#foo');
         $this->assertTrue($filter->match($uri3), 'http://php-spider.org/foo#bar');
         $this->assertTrue($filter->match($uri4), 'http://php-spider.org/foo/#bar');
-        $this->asserttrue($filter->match($uri5), 'http://php-spider.org#/foo/bar');
+        $this->assertTrue($filter->match($uri5), 'http://php-spider.org#/foo/bar');
     }
 }

--- a/tests/Filter/Prefetch/UriWithQueryStringFilterTest.php
+++ b/tests/Filter/Prefetch/UriWithQueryStringFilterTest.php
@@ -11,11 +11,9 @@
 
 namespace VDB\Spider\Tests\Filter\Prefetch;
 
-use ErrorException;
 use VDB\Spider\Filter\Prefetch\UriWithQueryStringFilter;
 use VDB\Spider\Tests\TestCase;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
+use VDB\Spider\Uri\DiscoveredUri;
 
 /**
  *
@@ -24,20 +22,17 @@ class UriWithQueryStringFilterTest extends TestCase
 {
     /**
      * @covers \VDB\Spider\Filter\Prefetch\UriWithQueryStringFilter
-     *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testMatch()
     {
         $filter = new UriWithQueryStringFilter();
 
-        $currentUri = 'http://php-spider.org';
-        $uri1 = new Uri('?', $currentUri);
-        $uri2 = new Uri('?foo=2', $currentUri);
-        $uri3 = new Uri('http://php-spider.org/foo?bar=baz', $currentUri);
-        $uri4 = new Uri('http://php-spider.org/foo/?bar=baz', $currentUri);
-        $uri5 = new Uri('http://php-spider.org?/foo/bar', $currentUri);
+        $currentUri = new DiscoveredUri('http://php-spider.org', 0);
+        $uri1 = new DiscoveredUri($currentUri->resolve('?'), 0);
+        $uri2 = new DiscoveredUri($currentUri->resolve('?foo=2'), 0);
+        $uri3 = new DiscoveredUri('http://php-spider.org/foo?bar=baz', 0);
+        $uri4 = new DiscoveredUri('http://php-spider.org/foo/?bar=baz', 0);
+        $uri5 = new DiscoveredUri('http://php-spider.org?/foo/bar', 0);
 
         $this->assertTrue($filter->match($uri1), '->match(\'?\')');
         $this->assertTrue($filter->match($uri2));

--- a/tests/Helpers/ResourceBuilder.php
+++ b/tests/Helpers/ResourceBuilder.php
@@ -5,7 +5,6 @@ namespace VDB\Spider\Tests\Helpers;
 use GuzzleHttp\Psr7\Response;
 use VDB\Spider\Resource;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Uri;
 
 /**
  * Test builder for creating Resource objects with sensible defaults.
@@ -125,7 +124,7 @@ class ResourceBuilder
      */
     public function build(): Resource
     {
-        $discoveredUri = new DiscoveredUri(new Uri($this->uri), $this->depth);
+        $discoveredUri = new DiscoveredUri($this->uri, $this->depth);
         $headers = array_filter(
             $this->headers,
             static fn ($value) => !is_array($value) || $value !== []
@@ -139,6 +138,6 @@ class ResourceBuilder
      */
     public function buildUri(): DiscoveredUri
     {
-        return new DiscoveredUri(new Uri($this->uri), $this->depth);
+        return new DiscoveredUri($this->uri, $this->depth);
     }
 }

--- a/tests/PersistenceHandler/FileSerializedResourcePersistenceHandlerTest.php
+++ b/tests/PersistenceHandler/FileSerializedResourcePersistenceHandlerTest.php
@@ -11,13 +11,11 @@
 
 namespace VDB\Spider\Tests\PersistenceHandler;
 
-use ErrorException;
 use GuzzleHttp\Psr7\Response;
 use VDB\Spider\PersistenceHandler\FileSerializedResourcePersistenceHandler;
 use VDB\Spider\Resource;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 /**
  * @SuppressWarnings(PHPMD.LongClassName)
@@ -45,8 +43,6 @@ class FileSerializedResourcePersistenceHandlerTest extends TestCase
      * @covers       \VDB\Spider\PersistenceHandler\FileSerializedResourcePersistenceHandler
      * @covers       \VDB\Spider\PersistenceHandler\FilePersistenceHandler
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testPathExtension()
     {
@@ -140,8 +136,6 @@ class FileSerializedResourcePersistenceHandlerTest extends TestCase
     }
 
     /**
-     * @throws UriSyntaxException
-     * @throws ErrorException
      */
     protected function buildPersistenceProviderRecord($fixturePath, $uriString): array
     {
@@ -168,8 +162,6 @@ class FileSerializedResourcePersistenceHandlerTest extends TestCase
     /**
      * @return array
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function persistenceProvider(): array
     {

--- a/tests/PersistenceHandler/MemoryPersistenceHandlerTest.php
+++ b/tests/PersistenceHandler/MemoryPersistenceHandlerTest.php
@@ -11,13 +11,11 @@
 
 namespace VDB\Spider\Tests\PersistenceHandler;
 
-use ErrorException;
 use GuzzleHttp\Psr7\Response;
 use VDB\Spider\PersistenceHandler\MemoryPersistenceHandler;
 use VDB\Spider\Resource;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 class MemoryPersistenceHandlerTest extends TestCase
 {
@@ -36,8 +34,6 @@ class MemoryPersistenceHandlerTest extends TestCase
      * @covers       \VDB\Spider\PersistenceHandler\MemoryPersistenceHandler
      * @covers       \VDB\Spider\PersistenceHandler\FilePersistenceHandler
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testPersist()
     {

--- a/tests/QueueManager/InMemoryQueueManagerTest.php
+++ b/tests/QueueManager/InMemoryQueueManagerTest.php
@@ -11,14 +11,12 @@
 
 namespace VDB\Spider\Tests\QueueManager;
 
-use ErrorException;
 use InvalidArgumentException;
 use VDB\Spider\Exception\MaxQueueSizeExceededException;
 use VDB\Spider\QueueManager\InMemoryQueueManager;
 use VDB\Spider\QueueManager\QueueManagerInterface;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 /**
  *
@@ -46,8 +44,6 @@ class InMemoryQueueManagerTest extends TestCase
     /**
      * @covers \VDB\Spider\QueueManager\InMemoryQueueManager
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testMaxQueueSizeExceeded()
     {
@@ -61,8 +57,6 @@ class InMemoryQueueManagerTest extends TestCase
     /**
      * @covers \VDB\Spider\QueueManager\InMemoryQueueManager
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      * @throws MaxQueueSizeExceededException
      */
     public function testDepthFirst()
@@ -82,8 +76,6 @@ class InMemoryQueueManagerTest extends TestCase
     /**
      * @covers \VDB\Spider\QueueManager\InMemoryQueueManager
      *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      * @throws MaxQueueSizeExceededException
      */
     public function testBreadthFirst()

--- a/tests/RequestHandler/GuzzleRequestHandlerTest.php
+++ b/tests/RequestHandler/GuzzleRequestHandlerTest.php
@@ -11,13 +11,11 @@
 
 namespace VDB\Spider\Tests\RequestHandler;
 
-use ErrorException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use VDB\Spider\RequestHandler\GuzzleRequestHandler;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 /**
  *
@@ -28,8 +26,6 @@ class GuzzleRequestHandlerTest extends TestCase
      * @covers \VDB\Spider\RequestHandler\GuzzleRequestHandler
      *
      * @throws GuzzleException
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testCustomClient()
     {

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -5,7 +5,6 @@ use GuzzleHttp\Psr7\Response;
 use VDB\Spider\Resource;
 use VDB\Spider\Tests\Helpers\ResourceBuilder;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Uri;
 
 /**
  */

--- a/tests/SpiderTest.php
+++ b/tests/SpiderTest.php
@@ -14,8 +14,6 @@ use VDB\Spider\QueueManager\QueueManagerInterface;
 use VDB\Spider\Resource;
 use VDB\Spider\Spider;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Http;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -100,7 +98,11 @@ class SpiderTest extends TestCase
         $this->assertSameSize($expected, $actual);
 
         foreach ($actual as $index => $resource) {
-            $this->assertEquals($resource->getUri(), $expected[$index]);
+            // Compare by string representation: DiscoveredUri wraps an internal
+            // Uri\Rfc3986\Uri instance that exposes no reflectable properties,
+            // so PHPUnit's object comparator cannot meaningfully diff two
+            // distinct instances via assertEquals($a, $b).
+            $this->assertEquals($expected[$index]->toString(), $resource->getUri()->toString());
         }
     }
 
@@ -247,6 +249,16 @@ class SpiderTest extends TestCase
         new Spider('fdsfnsd:t4rgevjk lffdsn');
     }
 
+    /**
+     * @covers \VDB\Spider\Spider
+     */
+    public function testNonHttpSeedFails()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid seed');
+        new Spider('ftp://example.com');
+    }
+
 
     /**
      * @covers \VDB\Spider\Spider
@@ -301,8 +313,6 @@ class SpiderTest extends TestCase
      *         | _ |
      *
      * Note: E links to F.
-     * @throws UriSyntaxException
-     * @throws ErrorException
      */
     protected function setUp(): void
     {
@@ -318,13 +328,13 @@ class SpiderTest extends TestCase
         $this->hrefF = 'http://php-spider.org/F';
         $this->hrefG = 'http://php-spider.org/G';
 
-        $this->linkA = new DiscoveredUri(new Http($this->hrefA), 0);
-        $this->linkB = new DiscoveredUri(new Http($this->hrefB), 1);
-        $this->linkC = new DiscoveredUri(new Http($this->hrefC), 1);
-        $this->linkD = new DiscoveredUri(new Http($this->hrefD), 2);
-        $this->linkE = new DiscoveredUri(new Http($this->hrefE), 1);
-        $this->linkF = new DiscoveredUri(new Http($this->hrefF), 2);
-        $this->linkG = new DiscoveredUri(new Http($this->hrefG), 2);
+        $this->linkA = new DiscoveredUri($this->hrefA, 0);
+        $this->linkB = new DiscoveredUri($this->hrefB, 1);
+        $this->linkC = new DiscoveredUri($this->hrefC, 1);
+        $this->linkD = new DiscoveredUri($this->hrefD, 2);
+        $this->linkE = new DiscoveredUri($this->hrefE, 1);
+        $this->linkF = new DiscoveredUri($this->hrefF, 2);
+        $this->linkG = new DiscoveredUri($this->hrefG, 2);
 
         $htmlA = file_get_contents(__DIR__ . '/Fixtures/SpiderTestHTMLResourceA.html');
         $this->responseA = new Response(200, [], $htmlA);
@@ -494,15 +504,15 @@ class SpiderTest extends TestCase
     public function testSetPersistenceHandlerWithMockDownloader()
     {
         $handler = $this->getMockBuilder('VDB\Spider\PersistenceHandler\PersistenceHandlerInterface')->getMock();
-        
+
         $mockDownloader = $this->getMockBuilder('VDB\Spider\Downloader\DownloaderInterface')->getMock();
         $mockDownloader->expects($this->once())
             ->method('setPersistenceHandler')
             ->with($handler);
-        
+
         $spider = new Spider($this->linkA, null, null, $mockDownloader);
         $result = $spider->setPersistenceHandler($handler);
-        
+
         $this->assertSame($spider, $result, 'Should return $this for chaining');
     }
 
@@ -515,10 +525,10 @@ class SpiderTest extends TestCase
         $mockQueueManager->expects($this->once())
             ->method('setMaxQueueSize')
             ->with(10);
-        
+
         $spider = new Spider($this->linkA, null, $mockQueueManager);
         $result = $spider->setMaxQueueSize(10);
-        
+
         $this->assertSame($spider, $result, 'Should return $this for chaining');
     }
 
@@ -534,15 +544,15 @@ class SpiderTest extends TestCase
                 $this->equalTo(SpiderEvents::SPIDER_CRAWL_PRE_REQUEST),
                 $this->anything()
             );
-        
+
         $mockDownloader = $this->getMockBuilder('VDB\Spider\Downloader\DownloaderInterface')->getMock();
         $mockDownloader->expects($this->once())
             ->method('getDispatcher')
             ->willReturn($mockDispatcher);
-        
+
         $spider = new Spider($this->linkA, null, null, $mockDownloader);
         $result = $spider->enablePolitenessPolicy(100);
-        
+
         $this->assertSame($spider, $result, 'Should return $this for chaining');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,13 +11,10 @@
 
 namespace VDB\Spider\Tests;
 
-use ErrorException;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use VDB\Spider\Resource;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
-use VDB\Uri\Uri;
 
 /**
  *
@@ -34,14 +31,10 @@ class TestCase extends PHPUnitTestCase
         return new Resource($uri, $response);
     }
 
-    /**
-     * @throws UriSyntaxException
-     * @throws ErrorException
-     */
     protected function buildResourceFromFixture($fixturePath, $uriString): Resource
     {
         return $this->getResource(
-            new DiscoveredUri(new Uri($uriString), 0),
+            new DiscoveredUri($uriString, 0),
             new Response(200, [], $this->getFixtureContent($fixturePath))
         );
     }

--- a/tests/Uri/DiscoveredUriTest.php
+++ b/tests/Uri/DiscoveredUriTest.php
@@ -10,10 +10,8 @@
 
 namespace VDB\Spider\Tests\Uri;
 
-use ErrorException;
 use VDB\Spider\Tests\TestCase;
 use VDB\Spider\Uri\DiscoveredUri;
-use VDB\Uri\Exception\UriSyntaxException;
 
 /**
  *
@@ -22,13 +20,53 @@ class DiscoveredUriTest extends TestCase
 {
     /**
      * @covers \VDB\Spider\Uri\DiscoveredUri
-     *
-     * @throws ErrorException
-     * @throws UriSyntaxException
      */
     public function testDepthFound()
     {
         $uri = new DiscoveredUri('http://example.org', 12);
         $this->assertEquals(12, $uri->getDepthFound());
+    }
+
+    /**
+     * @covers \VDB\Spider\Uri\DiscoveredUri
+     */
+    public function testProxyMethods()
+    {
+        $uri = new DiscoveredUri('http://user:pass@example.org:8080/path?q=1#frag', 0);
+
+        $this->assertEquals('http', $uri->getScheme());
+        $this->assertEquals('example.org', $uri->getHost());
+        $this->assertEquals(8080, $uri->getPort());
+        $this->assertEquals('/path', $uri->getPath());
+        $this->assertEquals('q=1', $uri->getQuery());
+        $this->assertEquals('frag', $uri->getFragment());
+        $this->assertEquals('user', $uri->getUsername());
+        $this->assertEquals('pass', $uri->getPassword());
+        $this->assertEquals('http://user:pass@example.org:8080/path?q=1#frag', $uri->toString());
+        $this->assertEquals('http://user:pass@example.org:8080/path?q=1#frag', (string) $uri);
+    }
+
+    /**
+     * @covers \VDB\Spider\Uri\DiscoveredUri
+     */
+    public function testResolve()
+    {
+        $uri = new DiscoveredUri('http://example.org/dir/page.html', 0);
+
+        $this->assertEquals('http://example.org/dir/other.html', $uri->resolve('other.html')->toString());
+        $this->assertEquals('http://other.org/abs', $uri->resolve('http://other.org/abs')->toString());
+    }
+
+    /**
+     * @covers \VDB\Spider\Uri\DiscoveredUri
+     */
+    public function testEquals()
+    {
+        $uri1 = new DiscoveredUri('http://example.org/path', 0);
+        $uri2 = new DiscoveredUri('http://example.org/path', 3);
+        $uri3 = new DiscoveredUri('http://example.org/other', 0);
+
+        $this->assertTrue($uri1->equals($uri2), 'Depth found should not affect equality');
+        $this->assertFalse($uri1->equals($uri3));
     }
 }


### PR DESCRIPTION
This is just for your information, feel free to ignore it or use it for a future release:
I have been working on a version of `php-spider` that does not depend on `vdp/uri` but instead uses the native `Uri\Rfc3986\Uri` of PHP >= 8.5
Of course, this breaks for any version < 8.5 which is fine in my use case but certainly not for most users.
It may be useful in the future, however.
~~I am currently testing it.~~ I've been testing it for a few days and it works fine.
I will be maintaining it on a 2.x branch on my fork.
Best regards